### PR TITLE
[REFACTOR] Update `NyxEngine` as a singleton that holds instances for main subclasses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: Automated Tests
 
 on:
   push:
@@ -22,13 +22,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black pytest numpy
+        pip install pytest numpy
     
     - name: Set up PYTHONPATH
       run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
       
-    - name: FORMATTING - Run black
-      run: black .
-
     - name: TESTS - Run tests
       run: pytest --disable-warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.10.8'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black pytest
+        pip install black pytest numpy
     
     - name: Set up PYTHONPATH
       run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy
+        pip install pytest numpy line_profiler
     
     - name: Set up PYTHONPATH
       run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 - Refactor `HemeraTermFx` to further optimize terminal printing performance.
+- Update `NyxEngine` as the main enforcer of game state consistency across the project. It now holds all instances of the major subclasses.
 
 ---
 
@@ -22,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Add an alient planet sprite to the current game demo in `main.py`.
 
 ### Changed
-- Optimize terminal printing string generation for a 95% reduction in frame printing time.
+- Optimize `HemeraTermFx` terminal printing string generation for a 95% reduction in frame printing time.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -97,6 +97,7 @@ def generate_planet(engine: NyxEngine):
 
 
 if __name__ == "__main__":
+    engine = NyxEngine()
     # Configs
     #Line profile string buffer printing:
     line_profiling = False
@@ -109,7 +110,6 @@ if __name__ == "__main__":
     window_width = 480
 
     # Start the engine
-    engine = NyxEngine()
     engine.hemera_term_fx.run_line_profile = line_profiling
     # Add required systems to loop
     engine.add_system(MovementSystem())

--- a/main.py
+++ b/main.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
         engine.render_frame()
         # Cull off-screen entities
         engine.kill_entities()
-        sleep_time = NyxEngine.sec_per_game_loop - (datetime.now() - start_time).seconds
+        sleep_time = engine.sec_per_game_loop - (datetime.now() - start_time).seconds
         time.sleep(sleep_time)
 
 

--- a/nyx/aether_renderer/aether_renderer.py
+++ b/nyx/aether_renderer/aether_renderer.py
@@ -167,11 +167,10 @@ class AetherRenderer:
             component (TilemapComponent): The component holding a tilemap array.
         """
         from nyx.nyx_engine.nyx_engine import NyxEngine
-
+        engine = NyxEngine()
         frame_w = self.dimensions.effective_window_w
         frame_h = self.dimensions.effective_window_h
 
-        # NyxEngine.tilemap_manager.render_tilemap()
-        self.layered_frames[0] = NyxEngine.tilemap_manager.rendered_tilemap[
+        self.layered_frames[0] = engine.tilemap_manager.rendered_tilemap[
             :frame_h, :frame_w
         ]

--- a/nyx/base_classes/base_manager.py
+++ b/nyx/base_classes/base_manager.py
@@ -1,0 +1,14 @@
+from abc import ABC
+
+from nyx.aether_renderer.aether_dimensions import AetherDimensions
+from nyx.nyx_engine.nyx_engine import NyxEngine
+
+
+class BaseManager:
+    @property
+    def engine(self) -> NyxEngine:
+        return NyxEngine()
+
+    @property
+    def dimensions(self) -> AetherDimensions:
+        return self.engine.aether_dimensions

--- a/nyx/hemera_term_fx/term_utils.py
+++ b/nyx/hemera_term_fx/term_utils.py
@@ -92,5 +92,11 @@ class TerminalUtils:
     @staticmethod
     def get_terminal_dimensions() -> Tuple[int, int]:
         """Return the terminal size as a tuple of integers in (h, w) format."""
-        terminal_size = os.get_terminal_size()
-        return (terminal_size.lines, terminal_size.columns)
+        try:
+            terminal_size = os.get_terminal_size()
+            h, w = terminal_size.lines, terminal_size.columns
+        except OSError:
+            # Triggers when running in a non-terminal env., such as during testing
+            # 10, 10 was used simply because it is not 0, 0; which may cause bound issues
+            h, w = 10, 10
+        return h, w

--- a/nyx/moirai_ecs/component/component_manager.py
+++ b/nyx/moirai_ecs/component/component_manager.py
@@ -29,18 +29,19 @@ class ComponentManager:
         destroy_compon(): Remove the a component from from the registry.
         remove_entity(): Remove all components belonging to an entity.
     """
-
-    # Component Registry
-    component_registry: Dict[str, Dict[int, NyxComponent]] = {
-        "background-color": {},
-        "dimensions": {},
-        "position": {},
-        "scene": {},
-        "texture": {},
-        "tilemap": {},
-        "velocity": {},
-        "z-index": {},
-    }
+    
+    def __init__(self):
+        # Component Registry
+        self.component_registry: Dict[str, Dict[int, NyxComponent]] = {
+            "background-color": {},
+            "dimensions": {},
+            "position": {},
+            "scene": {},
+            "texture": {},
+            "tilemap": {},
+            "velocity": {},
+            "z-index": {},
+        }
 
     def add_component(
         self, entity_id: int, component_name: str, component: NyxComponent
@@ -55,12 +56,12 @@ class ComponentManager:
         Raises:
             ValueError: If the component type is already registered for that entity ID.
         """
-        if entity_id in ComponentManager.component_registry[component_name]:
+        if entity_id in self.component_registry[component_name]:
             raise ValueError(
                 f'Component="{component_name}" already exists for entity={entity_id}'
             )
 
-        ComponentManager.component_registry[component_name][entity_id] = component
+        self.component_registry[component_name][entity_id] = component
 
     def get_component(self, entity_id: int, component_name: str) -> NyxComponent:
         """Get a component for an entity.
@@ -76,8 +77,8 @@ class ComponentManager:
             NyxComponent: The component retrieved.
         """
 
-        if entity_id in ComponentManager.component_registry[component_name]:
-            return ComponentManager.component_registry[component_name][entity_id]
+        if entity_id in self.component_registry[component_name]:
+            return self.component_registry[component_name][entity_id]
         raise KeyError(
             f'Entity={entity_id} not found in "{component_name}" component registry.'
         )
@@ -95,11 +96,11 @@ class ComponentManager:
         Raises:
             KeyError: If the entity_id is not found for that component type.
         """
-        if entity_id not in ComponentManager.component_registry[component_name]:
+        if entity_id not in self.component_registry[component_name]:
             raise KeyError(
                 f'Entity={entity_id} not found in "{component_name}" component registry.'
             )
-        ComponentManager.component_registry[component_name][entity_id] = component
+        self.component_registry[component_name][entity_id] = component
 
     def destroy_component(self, entity_id: int, component_name: str):
         """Remove the a component from from the registry.
@@ -111,19 +112,18 @@ class ComponentManager:
         Raises:
             KeyError: If the entity_id is not found for that component type.
         """
-        if entity_id not in ComponentManager.component_registry[component_name]:
+        if entity_id not in self.component_registry[component_name]:
             raise KeyError(
                 f'Entity={entity_id} not found in "{component_name}" component registry.'
             )
-        del ComponentManager.component_registry[component_name][entity_id]
+        del self.component_registry[component_name][entity_id]
 
-    @staticmethod
-    def remove_entity(entity_id: int):
+    def remove_entity(self, entity_id: int):
         """Remove all components belonging to an entity.
 
         Args:
             entity_id (int): The entity ID of the entity to clear from the registry.
         """
-        for sub_dict in ComponentManager.component_registry.values():
+        for sub_dict in self.component_registry.values():
             if entity_id in sub_dict.keys():
                 del sub_dict[entity_id]

--- a/nyx/moirai_ecs/component/component_manager.py
+++ b/nyx/moirai_ecs/component/component_manager.py
@@ -29,7 +29,7 @@ class ComponentManager:
         destroy_compon(): Remove the a component from from the registry.
         remove_entity(): Remove all components belonging to an entity.
     """
-    
+
     def __init__(self):
         # Component Registry
         self.component_registry: Dict[str, Dict[int, NyxComponent]] = {
@@ -102,7 +102,7 @@ class ComponentManager:
             )
         self.component_registry[component_name][entity_id] = component
 
-    def destroy_component(self, entity_id: int, component_name: str):
+    def remove_component(self, entity_id: int, component_name: str):
         """Remove the a component from from the registry.
 
         Args:

--- a/nyx/moirai_ecs/entity/moirai_entity_manager.py
+++ b/nyx/moirai_ecs/entity/moirai_entity_manager.py
@@ -45,7 +45,7 @@ class MoiraiEntityManager:
     def __init__(self, engine: "NyxEngine"):
         self.engine = engine
         self.component_manager = self.engine.component_manager
-        self.component_registry = self.component_manager.component_registry
+        self.component_registry = self.engine.component_registry
         self.entity_registry: Dict[int, NyxEntity] = {}
 
     def create_entity(self, friendly_name: str = "") -> NyxEntity:
@@ -59,7 +59,7 @@ class MoiraiEntityManager:
         """
 
         new_entity = NyxEntity(friendly_name=friendly_name.strip())
-        MoiraiEntityManager.entity_registry[new_entity.entity_id] = new_entity
+        self.entity_registry[new_entity.entity_id] = new_entity
         return new_entity
 
     def destroy_entity(self, entity_id: int):
@@ -68,8 +68,8 @@ class MoiraiEntityManager:
         Args:
             entity_id (int): The entity ID to remove.
         """
-        if entity_id in MoiraiEntityManager.entity_registry:
-            del MoiraiEntityManager.entity_registry[entity_id]
+        if entity_id in self.entity_registry:
+            del self.entity_registry[entity_id]
             self.component_manager.remove_entity(entity_id=entity_id)
         return self
 
@@ -82,7 +82,7 @@ class MoiraiEntityManager:
         Returns:
             bool: If the entity is alive.
         """
-        return entity_id in MoiraiEntityManager.entity_registry
+        return entity_id in self.entity_registry
 
     def get_entity(self, entity_id: int) -> NyxEntity:
         """Get an entity from the entity list
@@ -93,8 +93,8 @@ class MoiraiEntityManager:
         Returns:
             NyxEntity: The entity with the specified entity ID.
         """
-        if entity_id in MoiraiEntityManager.entity_registry:
-            return MoiraiEntityManager.entity_registry[entity_id]
+        if entity_id in self.entity_registry:
+            return self.entity_registry[entity_id]
 
     def get_all_entities(self) -> Dict[int, NyxEntity]:
         """Return a registry of all entities in this manager.
@@ -102,4 +102,4 @@ class MoiraiEntityManager:
         Returns:
             Dict[int, NyxEntity]: The registry of NyxEntity objects.
         """
-        return MoiraiEntityManager.entity_registry
+        return self.entity_registry

--- a/nyx/moirai_ecs/entity/moirai_entity_manager.py
+++ b/nyx/moirai_ecs/entity/moirai_entity_manager.py
@@ -14,9 +14,11 @@ Mythology:
     the path that life will follow; and Atropos cuts the thread, ending that life's journey.
 """
 
-from typing import Dict
-from nyx.moirai_ecs.component.component_manager import ComponentManager
+from typing import Dict, TYPE_CHECKING
 from nyx.moirai_ecs.entity.nyx_entity import NyxEntity
+
+if TYPE_CHECKING:
+    from nyx.nyx_engine.nyx_engine import NyxEngine
 
 
 class MoiraiEntityManager:
@@ -40,6 +42,12 @@ class MoiraiEntityManager:
         """Clear the entity registry of all entities."""
         cls.entity_registry.clear()
 
+    def __init__(self, engine: "NyxEngine"):
+        self.engine = engine
+        self.component_manager = self.engine.component_manager
+        self.component_registry = self.component_manager.component_registry
+        self.entity_registry: Dict[int, NyxEntity] = {}
+
     def create_entity(self, friendly_name: str = "") -> NyxEntity:
         """Create a NyxEntity and add it to the entity registry.
 
@@ -62,7 +70,7 @@ class MoiraiEntityManager:
         """
         if entity_id in MoiraiEntityManager.entity_registry:
             del MoiraiEntityManager.entity_registry[entity_id]
-            ComponentManager.remove_entity(entity_id=entity_id)
+            self.component_manager.remove_entity(entity_id=entity_id)
         return self
 
     def is_alive(self, entity_id: int) -> bool:

--- a/nyx/moirai_ecs/system/aether_bridge_system.py
+++ b/nyx/moirai_ecs/system/aether_bridge_system.py
@@ -12,7 +12,6 @@ Classes:
 from typing import Dict, List, Tuple
 
 import numpy as np
-from nyx.moirai_ecs.component.component_manager import ComponentManager
 from nyx.moirai_ecs.system.base_systems import BaseSystem
 
 
@@ -32,7 +31,7 @@ class AetherBridgeSystem(BaseSystem):
 
     def update(self):
         """Gather all renderable entities and components, then pass them to AetherRenderer."""
-        component_registry = ComponentManager.component_registry
+        component_registry = self.engine.component_registry
         renderable_entities = {}
         # scene_entities = {}
 

--- a/nyx/moirai_ecs/system/base_systems.py
+++ b/nyx/moirai_ecs/system/base_systems.py
@@ -19,5 +19,4 @@ class BaseSystem(ABC):
     def engine(self) -> "NyxEngine":
         """Return the engine instance."""
         from nyx.nyx_engine.nyx_engine import NyxEngine
-
         return NyxEngine()

--- a/nyx/moirai_ecs/system/base_systems.py
+++ b/nyx/moirai_ecs/system/base_systems.py
@@ -6,7 +6,18 @@ from.
 """
 
 from abc import ABC
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nyx.nyx_engine.nyx_engine import NyxEngine
 
 
 class BaseSystem(ABC):
-    """The base system class, which all systems in the ECS architechture inherit from."""
+    """The base system class, which all systems in the ECS architecture inherit from."""
+
+    @property
+    def engine(self) -> "NyxEngine":
+        """Return the engine instance."""
+        from nyx.nyx_engine.nyx_engine import NyxEngine
+
+        return NyxEngine()

--- a/nyx/moirai_ecs/system/base_systems.py
+++ b/nyx/moirai_ecs/system/base_systems.py
@@ -7,8 +7,6 @@ from.
 
 from abc import ABC
 
-from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
-
 
 class BaseSystem(ABC):
     """The base system class, which all systems in the ECS architechture inherit from."""

--- a/nyx/moirai_ecs/system/movement_system.py
+++ b/nyx/moirai_ecs/system/movement_system.py
@@ -8,12 +8,10 @@ Classes:
 """
 
 from typing import Dict
-from nyx.moirai_ecs.component.component_manager import ComponentManager
 from nyx.moirai_ecs.component.transform_components import (
     PositionComponent,
     VelocityComponent,
 )
-from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
 from nyx.moirai_ecs.system.base_systems import BaseSystem
 from nyx.nyx_engine.nyx_engine import NyxEngine
 
@@ -30,7 +28,7 @@ class MovementSystem(BaseSystem):
         """
         engine = self.engine
         component_registry = engine.component_registry
-        entity_reg = MoiraiEntityManager.entity_registry
+        entity_reg = engine.entity_manager.entity_registry
         position_reg: Dict[int, PositionComponent] = (
             component_registry["position"]
         )

--- a/nyx/moirai_ecs/system/movement_system.py
+++ b/nyx/moirai_ecs/system/movement_system.py
@@ -35,7 +35,8 @@ class MovementSystem(BaseSystem):
         velocity_reg: Dict[int, VelocityComponent] = (
             ComponentManager.component_registry["velocity"]
         )
-        dt = NyxEngine.sec_per_game_loop
+        engine = NyxEngine()
+        dt = engine.sec_per_game_loop
 
         # Update the position of each entity
         for entity_id, velocity_component in velocity_reg.items():

--- a/nyx/moirai_ecs/system/movement_system.py
+++ b/nyx/moirai_ecs/system/movement_system.py
@@ -28,12 +28,14 @@ class MovementSystem(BaseSystem):
         Note:
             Calculates both the actual position and the position to render on the screen.
         """
+        engine = self.engine
+        component_registry = engine.component_registry
         entity_reg = MoiraiEntityManager.entity_registry
         position_reg: Dict[int, PositionComponent] = (
-            ComponentManager.component_registry["position"]
+            component_registry["position"]
         )
         velocity_reg: Dict[int, VelocityComponent] = (
-            ComponentManager.component_registry["velocity"]
+            component_registry["velocity"]
         )
         engine = NyxEngine()
         dt = engine.sec_per_game_loop

--- a/nyx/nyx_engine/nyx_engine.py
+++ b/nyx/nyx_engine/nyx_engine.py
@@ -40,15 +40,6 @@ class NyxEngine:
         render_frame(): Renders the current frame.
     """
 
-
-
-    entity_manager = MoiraiEntityManager()
-    component_manager = ComponentManager()
-    aether_bridge = AetherBridgeSystem()
-    aether_renderer = AetherRenderer()
-    hemera_term_fx = HemeraTermFx()
-    tilemap_manager = TilemapManager(dimensions=aether_renderer.dimensions)
-
     # Singleton instance
     _instance = None
 

--- a/nyx/nyx_engine/nyx_engine.py
+++ b/nyx/nyx_engine/nyx_engine.py
@@ -10,6 +10,7 @@ Classes:
 import time
 from typing import TYPE_CHECKING
 
+from nyx.aether_renderer.aether_dimensions import AetherDimensions
 from nyx.aether_renderer.aether_renderer import AetherRenderer
 from nyx.aether_renderer.tilemap_manager import TilemapManager
 from nyx.hemera_term_fx.hemera_term_fx import HemeraTermFx
@@ -60,13 +61,16 @@ class NyxEngine:
             self.game_update_per_sec = 60
             self.sec_per_game_loop = 1 / self.game_update_per_sec
             self.running_systems = []
-            self.component_manager = ComponentManager()
+            self.component_manager: ComponentManager = ComponentManager()
             self.component_registry = self.component_manager.component_registry
-            self.entity_manager = MoiraiEntityManager(self)
-            self.aether_bridge = AetherBridgeSystem()
-            self.aether_renderer = AetherRenderer()
-            self.hemera_term_fx = HemeraTermFx()
-            self.tilemap_manager = TilemapManager(dimensions=self.aether_renderer.dimensions)
+            self.entity_manager: MoiraiEntityManager = MoiraiEntityManager(self)
+            self.aether_bridge: AetherBridgeSystem = AetherBridgeSystem()
+            self.aether_renderer: AetherRenderer = AetherRenderer()
+            self.aether_dimensions: AetherDimensions = self.aether_renderer.dimensions
+            self.hemera_term_fx: HemeraTermFx = HemeraTermFx()
+            self.tilemap_manager: TilemapManager = TilemapManager(
+                dimensions=self.aether_dimensions
+            )
 
     def run_game(self):
         """The main game loop."""

--- a/nyx/nyx_engine/nyx_engine.py
+++ b/nyx/nyx_engine/nyx_engine.py
@@ -58,7 +58,8 @@ class NyxEngine:
         if not hasattr(self, "initialized"):
             self.initialized = True
             self.is_running = False
-            self.fps_target = 5
+            self.fps_target = 30
+            self.sec_per_frame = 1 / self.fps_target
             self.game_update_per_sec = 60
             self.sec_per_game_loop = 1 / self.game_update_per_sec
             self.running_systems: List[BaseSystem] = []

--- a/nyx/nyx_engine/nyx_engine.py
+++ b/nyx/nyx_engine/nyx_engine.py
@@ -8,6 +8,7 @@ Classes:
 """
 
 import time
+from typing import TYPE_CHECKING
 
 from nyx.aether_renderer.aether_renderer import AetherRenderer
 from nyx.aether_renderer.tilemap_manager import TilemapManager
@@ -15,7 +16,10 @@ from nyx.hemera_term_fx.hemera_term_fx import HemeraTermFx
 from nyx.moirai_ecs.component.component_manager import ComponentManager
 from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
 from nyx.moirai_ecs.system.aether_bridge_system import AetherBridgeSystem
-from nyx.moirai_ecs.system.base_systems import BaseSystem
+
+
+if TYPE_CHECKING:
+    from nyx.moirai_ecs.system.base_systems import BaseSystem
 
 
 class NyxEngine:
@@ -56,8 +60,9 @@ class NyxEngine:
             self.game_update_per_sec = 60
             self.sec_per_game_loop = 1 / self.game_update_per_sec
             self.running_systems = []
-            self.entity_manager = MoiraiEntityManager()
             self.component_manager = ComponentManager()
+            self.component_registry = self.component_manager.component_registry
+            self.entity_manager = MoiraiEntityManager(self)
             self.aether_bridge = AetherBridgeSystem()
             self.aether_renderer = AetherRenderer()
             self.hemera_term_fx = HemeraTermFx()
@@ -70,11 +75,11 @@ class NyxEngine:
             self.render_frame()
             time.sleep(self.sec_per_game_loop)
 
-    def add_system(self, system: BaseSystem):
+    def add_system(self, system: "BaseSystem"):
         """Adds a system to the running systems list.
 
         Args:
-            system (BaseSystem): The system to add.
+            system ("BaseSystem"): The system to add.
         """
         self.running_systems.append(system)
 

--- a/nyx/nyx_engine/nyx_engine.py
+++ b/nyx/nyx_engine/nyx_engine.py
@@ -8,12 +8,13 @@ Classes:
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 
 from nyx.aether_renderer.aether_dimensions import AetherDimensions
 from nyx.aether_renderer.aether_renderer import AetherRenderer
 from nyx.aether_renderer.tilemap_manager import TilemapManager
 from nyx.hemera_term_fx.hemera_term_fx import HemeraTermFx
+from nyx.moirai_ecs.component.base_components import NyxComponent
 from nyx.moirai_ecs.component.component_manager import ComponentManager
 from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
 from nyx.moirai_ecs.system.aether_bridge_system import AetherBridgeSystem
@@ -60,9 +61,9 @@ class NyxEngine:
             self.fps_target = 5
             self.game_update_per_sec = 60
             self.sec_per_game_loop = 1 / self.game_update_per_sec
-            self.running_systems = []
+            self.running_systems: List[BaseSystem] = []
             self.component_manager: ComponentManager = ComponentManager()
-            self.component_registry = self.component_manager.component_registry
+            self.component_registry: Dict[str, Dict[int, NyxComponent]]  = self.component_manager.component_registry
             self.entity_manager: MoiraiEntityManager = MoiraiEntityManager(self)
             self.aether_bridge: AetherBridgeSystem = AetherBridgeSystem()
             self.aether_renderer: AetherRenderer = AetherRenderer()

--- a/tests/test_moirai_ecs/test_component/test_component_manager.py
+++ b/tests/test_moirai_ecs/test_component/test_component_manager.py
@@ -20,7 +20,7 @@ def test_add_component():
     component_manager.add_component(
         entity_id=entity_id, component_name="dimensions", component=component
     )
-    assert component in ComponentManager.component_registry["dimensions"].values()
+    assert component in component_manager.component_registry["dimensions"].values()
 
 
 def test_get_component():
@@ -55,7 +55,7 @@ def test_update_component():
     component_manager.update_component(
         entity_id=entity_id, component_name=component_name, component=component_2
     )
-    assert component_2 in ComponentManager.component_registry[component_name].values()
+    assert component_2 in component_manager.component_registry[component_name].values()
 
 
 def test_destroy_component():
@@ -72,7 +72,7 @@ def test_destroy_component():
         entity_id=entity_id, component_name=component_name
     )
 
-    assert component not in ComponentManager.component_registry[component_name].values()
+    assert component not in component_manager.component_registry[component_name].values()
 
 
 def test_remove_entity():
@@ -98,5 +98,5 @@ def test_remove_entity():
 
     component_manager.remove_entity(entity_id=entity_id)
 
-    for sub_dict in ComponentManager.component_registry.values():
+    for sub_dict in component_manager.component_registry.values():
         assert entity_id not in sub_dict.keys()

--- a/tests/test_moirai_ecs/test_component/test_component_manager.py
+++ b/tests/test_moirai_ecs/test_component/test_component_manager.py
@@ -68,11 +68,13 @@ def test_destroy_component():
     component_manager.add_component(
         entity_id=entity_id, component_name=component_name, component=component
     )
-    component_manager.destroy_component(
+    component_manager.remove_component(
         entity_id=entity_id, component_name=component_name
     )
 
-    assert component not in component_manager.component_registry[component_name].values()
+    assert (
+        component not in component_manager.component_registry[component_name].values()
+    )
 
 
 def test_remove_entity():

--- a/tests/test_moirai_ecs/test_entity/test_entity_manager.py
+++ b/tests/test_moirai_ecs/test_entity/test_entity_manager.py
@@ -1,92 +1,94 @@
-from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
-from nyx.moirai_ecs.entity.nyx_entity import NyxEntity
+"""Need to mock the engine because AetherDimensions does not allow for setting a
+terminal size within a pytest test."""
+# from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
+# from nyx.moirai_ecs.entity.nyx_entity import NyxEntity
+# from nyx.nyx_engine.nyx_engine import NyxEngine
+
+# def test_entity_manager_construction():
+#     """Test that the entity manager can be initialized."""
+#     assert isinstance(MoiraiEntityManager(NyxEngine()), MoiraiEntityManager)
 
 
-def test_entity_manager_construction():
-    """Test that the entity manager can be initialized."""
-    assert isinstance(MoiraiEntityManager(), MoiraiEntityManager)
+# def test_create_entities():
+#     """Test the creation of entities (create, add to reg, return)."""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_list = []
+
+#     for i in range(10):
+#         entity_list.append(entity_fate_manager.create_entity())
+
+#     for entity in entity_list:
+#         assert entity in entity_list
 
 
-def test_create_entities():
-    """Test the creation of entities (create, add to reg, return)."""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_list = []
+# def test_reset_entity_registry():
+#     """Test clearing the entire entity registry"""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_list = []
 
-    for i in range(10):
-        entity_list.append(entity_fate_manager.create_entity())
+#     # Create the entitiies
+#     for i in range(10):
+#         entity_list.append(entity_fate_manager.create_entity())
 
-    for entity in entity_list:
-        assert entity in entity_list
+#     # Clear the registry
+#     entity_fate_manager.reset_entity_registry()
 
+#     # Get the cleared registry
+#     entity_manager_list = MoiraiEntityManager.entity_registry
 
-def test_reset_entity_registry():
-    """Test clearing the entire entity registry"""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_list = []
-
-    # Create the entitiies
-    for i in range(10):
-        entity_list.append(entity_fate_manager.create_entity())
-
-    # Clear the registry
-    entity_fate_manager.reset_entity_registry()
-
-    # Get the cleared registry
-    entity_manager_list = MoiraiEntityManager.entity_registry
-
-    # Remove the entities
-    for entity in entity_list:
-        assert entity.entity_id not in entity_manager_list
+#     # Remove the entities
+#     for entity in entity_list:
+#         assert entity.entity_id not in entity_manager_list
 
 
-def test_destroy_entity():
-    """Test the destruction of entities."""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_fate_manager.reset_entity_registry()
-    entity_list = []
+# def test_destroy_entity():
+#     """Test the destruction of entities."""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_fate_manager.reset_entity_registry()
+#     entity_list = []
 
-    # Create the entities
-    for i in range(10):
-        entity_list.append(entity_fate_manager.create_entity())
+#     # Create the entities
+#     for i in range(10):
+#         entity_list.append(entity_fate_manager.create_entity())
 
-    # Get the registry
-    entity_manager_list = MoiraiEntityManager.entity_registry
+#     # Get the registry
+#     entity_manager_list = MoiraiEntityManager.entity_registry
 
-    # Remove the entities
-    for entity in entity_list:
-        entity_fate_manager.destroy_entity(entity.entity_id)
-        assert entity.entity_id not in entity_manager_list
-
-
-def test_is_alive():
-    """Test if an entity is present in the entity list."""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_fate_manager.reset_entity_registry()
-    entity_fate_manager.create_entity()
-
-    assert entity_fate_manager.is_alive(entity_fate_manager.create_entity().entity_id)
-    assert not entity_fate_manager.is_alive(-1)
+#     # Remove the entities
+#     for entity in entity_list:
+#         entity_fate_manager.destroy_entity(entity.entity_id)
+#         assert entity.entity_id not in entity_manager_list
 
 
-def test_get_entity():
-    """Test getting a single, existing entity"""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_fate_manager.reset_entity_registry()
+# def test_is_alive():
+#     """Test if an entity is present in the entity list."""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_fate_manager.reset_entity_registry()
+#     entity_fate_manager.create_entity()
 
-    assert isinstance(
-        entity_fate_manager.get_entity(entity_fate_manager.create_entity().entity_id),
-        NyxEntity,
-    )
+#     assert entity_fate_manager.is_alive(entity_fate_manager.create_entity().entity_id)
+#     assert not entity_fate_manager.is_alive(-1)
 
 
-def test_get_all_entities():
-    """Test getting all entities from the manager"""
-    entity_fate_manager = MoiraiEntityManager()
-    entity_fate_manager.reset_entity_registry()
-    entity_list = []
+# def test_get_entity():
+#     """Test getting a single, existing entity"""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_fate_manager.reset_entity_registry()
 
-    # Create the entities
-    for _ in range(10):
-        entity_list.append(entity_fate_manager.create_entity())
+#     assert isinstance(
+#         entity_fate_manager.get_entity(entity_fate_manager.create_entity().entity_id),
+#         NyxEntity,
+#     )
 
-    assert len(entity_fate_manager.get_all_entities()) == 10
+
+# def test_get_all_entities():
+#     """Test getting all entities from the manager"""
+#     entity_fate_manager = MoiraiEntityManager()
+#     entity_fate_manager.reset_entity_registry()
+#     entity_list = []
+
+#     # Create the entities
+#     for _ in range(10):
+#         entity_list.append(entity_fate_manager.create_entity())
+
+#     assert len(entity_fate_manager.get_all_entities()) == 10

--- a/tests/test_moirai_ecs/test_entity/test_entity_manager.py
+++ b/tests/test_moirai_ecs/test_entity/test_entity_manager.py
@@ -1,94 +1,93 @@
-"""Need to mock the engine because AetherDimensions does not allow for setting a
-terminal size within a pytest test."""
-# from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
-# from nyx.moirai_ecs.entity.nyx_entity import NyxEntity
-# from nyx.nyx_engine.nyx_engine import NyxEngine
 
-# def test_entity_manager_construction():
-#     """Test that the entity manager can be initialized."""
-#     assert isinstance(MoiraiEntityManager(NyxEngine()), MoiraiEntityManager)
+from nyx.moirai_ecs.entity.moirai_entity_manager import MoiraiEntityManager
+from nyx.moirai_ecs.entity.nyx_entity import NyxEntity
+from nyx.nyx_engine.nyx_engine import NyxEngine
 
-
-# def test_create_entities():
-#     """Test the creation of entities (create, add to reg, return)."""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_list = []
-
-#     for i in range(10):
-#         entity_list.append(entity_fate_manager.create_entity())
-
-#     for entity in entity_list:
-#         assert entity in entity_list
+def test_entity_manager_construction():
+    """Test that the entity manager can be initialized."""
+    assert isinstance(MoiraiEntityManager(NyxEngine()), MoiraiEntityManager)
 
 
-# def test_reset_entity_registry():
-#     """Test clearing the entire entity registry"""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_list = []
+def test_create_entities():
+    """Test the creation of entities (create, add to reg, return)."""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_list = []
 
-#     # Create the entitiies
-#     for i in range(10):
-#         entity_list.append(entity_fate_manager.create_entity())
+    for i in range(10):
+        entity_list.append(entity_fate_manager.create_entity())
 
-#     # Clear the registry
-#     entity_fate_manager.reset_entity_registry()
-
-#     # Get the cleared registry
-#     entity_manager_list = MoiraiEntityManager.entity_registry
-
-#     # Remove the entities
-#     for entity in entity_list:
-#         assert entity.entity_id not in entity_manager_list
+    for entity in entity_list:
+        assert entity in entity_list
 
 
-# def test_destroy_entity():
-#     """Test the destruction of entities."""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_fate_manager.reset_entity_registry()
-#     entity_list = []
+def test_reset_entity_registry():
+    """Test clearing the entire entity registry"""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_list = []
 
-#     # Create the entities
-#     for i in range(10):
-#         entity_list.append(entity_fate_manager.create_entity())
+    # Create the entitiies
+    for i in range(10):
+        entity_list.append(entity_fate_manager.create_entity())
 
-#     # Get the registry
-#     entity_manager_list = MoiraiEntityManager.entity_registry
+    # Clear the registry
+    entity_fate_manager.reset_entity_registry()
 
-#     # Remove the entities
-#     for entity in entity_list:
-#         entity_fate_manager.destroy_entity(entity.entity_id)
-#         assert entity.entity_id not in entity_manager_list
+    # Get the cleared registry
+    entity_manager_list = MoiraiEntityManager.entity_registry
 
-
-# def test_is_alive():
-#     """Test if an entity is present in the entity list."""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_fate_manager.reset_entity_registry()
-#     entity_fate_manager.create_entity()
-
-#     assert entity_fate_manager.is_alive(entity_fate_manager.create_entity().entity_id)
-#     assert not entity_fate_manager.is_alive(-1)
+    # Remove the entities
+    for entity in entity_list:
+        assert entity.entity_id not in entity_manager_list
 
 
-# def test_get_entity():
-#     """Test getting a single, existing entity"""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_fate_manager.reset_entity_registry()
+def test_destroy_entity():
+    """Test the destruction of entities."""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_fate_manager.reset_entity_registry()
+    entity_list = []
 
-#     assert isinstance(
-#         entity_fate_manager.get_entity(entity_fate_manager.create_entity().entity_id),
-#         NyxEntity,
-#     )
+    # Create the entities
+    for i in range(10):
+        entity_list.append(entity_fate_manager.create_entity())
+
+    # Get the registry
+    entity_manager_list = MoiraiEntityManager.entity_registry
+
+    # Remove the entities
+    for entity in entity_list:
+        entity_fate_manager.destroy_entity(entity.entity_id)
+        assert entity.entity_id not in entity_manager_list
 
 
-# def test_get_all_entities():
-#     """Test getting all entities from the manager"""
-#     entity_fate_manager = MoiraiEntityManager()
-#     entity_fate_manager.reset_entity_registry()
-#     entity_list = []
+def test_is_alive():
+    """Test if an entity is present in the entity list."""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_fate_manager.reset_entity_registry()
+    entity_fate_manager.create_entity()
 
-#     # Create the entities
-#     for _ in range(10):
-#         entity_list.append(entity_fate_manager.create_entity())
+    assert entity_fate_manager.is_alive(entity_fate_manager.create_entity().entity_id)
+    assert not entity_fate_manager.is_alive(-1)
 
-#     assert len(entity_fate_manager.get_all_entities()) == 10
+
+def test_get_entity():
+    """Test getting a single, existing entity"""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_fate_manager.reset_entity_registry()
+
+    assert isinstance(
+        entity_fate_manager.get_entity(entity_fate_manager.create_entity().entity_id),
+        NyxEntity,
+    )
+
+
+def test_get_all_entities():
+    """Test getting all entities from the manager"""
+    entity_fate_manager = MoiraiEntityManager(NyxEngine())
+    entity_fate_manager.reset_entity_registry()
+    entity_list = []
+
+    # Create the entities
+    for _ in range(10):
+        entity_list.append(entity_fate_manager.create_entity())
+
+    assert len(entity_fate_manager.get_all_entities()) == 10


### PR DESCRIPTION
# [REFACTOR] Update `NyxEngine` as a singleton that holds instances for main subclasses

## Overview

The `NyxEngine` class has been updated to be a singletime that holds instances for the main
subclasses. This change was made to simplify the process of accessing the main subclasses and to
ensure that only one instance of each subclass is created.

Now any class that needs to access the main subclasses can do so by calling the `NyxEngine` class,
which brings along with it the correct instances of the main subclasses.

This solves:
- The need to pass the main subclasses around as parameters (which becomes cumbersome as the
  project grows).
- Ensuring state consistency across the project by having only one instance of each main subclass
  and only "allowing" them to be created in the `NyxEngine` class.
- Using class attributes to store subclass data; now the `NyxEngine` class is responsible for
  managing the instances of the main subclasses and providing them to other classes.

## Changes Made

Changes were fairly widespread across the project, but the main changes were made were:
- Refactoring the `NyxEngine` class to be a singleton.
- Updating the main subclasses to be created and stored in the `NyxEngine` class' instance.
- Removing class attributes from the main subclasses and updating the classes that used them to
  access the instances from the `NyxEngine` class.
- Adding error-checking to the `TermUtils` class to gracefully handle when operating outside of a
  terminal environment.
- Update tests to reflect the changes made to the main subclasses.

---

Closes #37, #38